### PR TITLE
time.time() is not implemented in CircuitPython on STM32

### DIFF
--- a/library/pms5003/__init__.py
+++ b/library/pms5003/__init__.py
@@ -122,12 +122,12 @@ class PMS5003():
         self._reset.value = True
 
     def read(self):
-        start = time.time()
+        start = time.monotonic()
 
         sof_index = 0
 
         while True:
-            elapsed = time.time() - start
+            elapsed = time.monotonic() - start
             if elapsed > 5:
                 raise ReadTimeoutError("PMS5003 Read Timeout: Could not find start of frame")
 


### PR DESCRIPTION
I am porting FeatherWing EnviroPlus to the STM32 and there is no RTC in STM32.
So this solve the problem for me and should work on Pi and other board.